### PR TITLE
chore: add network support for arbitrum and optimism

### DIFF
--- a/contract/.env.sample
+++ b/contract/.env.sample
@@ -13,13 +13,19 @@ CREATE2_FACTORY_CALLER_ADDRESS=0x525C9Baa87aDddDc23C2F01Aa9d0c010c722c9Bf       
 # mainnet RPCs
 MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/your-api-key
 BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/your-api-key
+OPTIMISM_RPC_URL=https://opt-mainnet.g.alchemy.com/v2/your-api-key
+ARBITRUM_RPC_URL=https://arb-mainnet.g.alchemy.com/v2/your-api-key
 # testnet RPCs
 SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/your-api-key
 BASE_SEPOLIA_RPC_URL=https://base-sepolia.g.alchemy.com/v2/your-api-key
+OPTIMISM_SEPOLIA_RPC_URL=https://opt-sepolia.g.alchemy.com/v2/your-api-key
+ARBITRUM_SEPOLIA_RPC_URL=https://arb-sepolia.g.alchemy.com/v2/your-api-key
 
 # ===== CONTRACT VERIFICATION =====
 ETHERSCAN_API_KEY=
 BASESCAN_API_KEY=
+OPTIMISM_API_KEY=
+ARBITRUM_API_KEY=
 
 # ===== EXECUTION MODE =====
 PROPOSE_TX=true             # Set to true to propose a transaction to Safe

--- a/contract/config.ts
+++ b/contract/config.ts
@@ -35,10 +35,14 @@ export const CONFIG = {
         // Mainnet URLs
         mainnet: 'https://safe-transaction-mainnet.safe.global',
         base: 'https://safe-transaction-base.safe.global',
+        optimism: 'https://safe-transaction-optimism.safe.global',
+        arbitrum: 'https://safe-transaction-arbitrum.safe.global',
 
         // Testnet URLs
         sepolia: 'https://safe-transaction-sepolia.safe.global',
-        baseSepolia: 'https://safe-transaction-base-sepolia.safe.global'
+        baseSepolia: 'https://safe-transaction-base-sepolia.safe.global',
+        optimismSepolia: 'https://safe-transaction-optimism-sepolia.safe.global',
+        arbitrumSepolia: 'https://safe-transaction-arbitrum-sepolia.safe.global',
     },
 
     /**
@@ -55,17 +59,32 @@ export const CONFIG = {
     useLedger: process.env.USE_LEDGER === "true",
     ledgerAddress: process.env.LEDGER_ADDRESS || "",
     network: {
+        // ===== Mainnet Networks =====
         mainnet: {
             BTreeTokenAddress: '0x6bDdE71Cf0C751EB6d5EdB8418e43D3d9427e436'
         },
         base: {
             BTreeTokenAddress: '0x4aCFF883f2879e69e67B7003ccec56C73ee41F6f'
         },
+        optimism: {
+            BTreeTokenAddress: '0xB260d236F5eA5094D31F016160705ff53ac45028'
+        },
+        arbitrum: {
+            BTreeTokenAddress: '0xA29871E78FC005d31982f942E1569265BA145A34'
+        },
+
+        // ===== Testnet Networks =====
         sepolia: {
             BTreeTokenAddress: '0x8389eFa79EF27De249AF63f034D7A94dFBdd4cBE'
         },
         baseSepolia: {
             BTreeTokenAddress: '0xF8c91a56db8485FCee21c5bf6345B063Cf4228F6'
+        },
+        optimismSepolia: {
+            BTreeTokenAddress: '0x7E5A0b6C5c32883AE8E5b830c05688Eff317c3fb'
+        },
+        arbitrumSepolia: {
+            BTreeTokenAddress: '0x65414D6A6DF9A139a462c2F43199dE580A348dF9'
         },
     },
 };

--- a/contract/hardhat.config.ts
+++ b/contract/hardhat.config.ts
@@ -42,6 +42,22 @@ const config: HardhatUserConfig = {
                 : [],
             accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
         },
+        optimism: {
+            url: process.env.OPTIMISM_RPC_URL,
+            chainId: 10,
+            ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
+                ? [process.env.LEDGER_ADDRESS]
+                : [],
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
+        arbitrum: {
+            url: process.env.ARBITRUM_RPC_URL,
+            chainId: 42161,
+            ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
+                ? [process.env.LEDGER_ADDRESS]
+                : [],
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
 
         // ===== Testnet Networks =====
         sepolia: {
@@ -60,16 +76,39 @@ const config: HardhatUserConfig = {
                 : [],
             accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
         },
-
+        optimismSepolia: {
+            url: process.env.OPTIMISM_SEPOLIA_RPC_URL,
+            chainId: 11155420,
+            ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
+                ? [process.env.LEDGER_ADDRESS]
+                : [],
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
+        arbitrumSepolia: {
+            url: process.env.ARBITRUM_SEPOLIA_RPC_URL,
+            chainId: 421614,
+            ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
+                ? [process.env.LEDGER_ADDRESS]
+                : [],
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
     },
     etherscan: {
         apiKey: {
+            // ===== Mainnet Networks =====
             mainnet: process.env.ETHERSCAN_API_KEY || '',
             base: process.env.BASESCAN_API_KEY || '',
+            optimism: process.env.OPTIMISM_API_KEY || '',
+            arbitrum: process.env.ARBISCAN_API_KEY || '',
+
+            // ===== Testnet Networks =====
             sepolia: process.env.ETHERSCAN_API_KEY || '',
             baseSepolia: process.env.BASESCAN_API_KEY || '',
+            optimismSepolia: process.env.OPTIMISM_API_KEY || '',
+            arbitrumSepolia: process.env.ARBISCAN_API_KEY || '',
         },
         customChains: [
+            // ===== Mainnet Networks =====
             {
                 network: 'mainnet',
                 chainId: 1,
@@ -87,6 +126,24 @@ const config: HardhatUserConfig = {
                 },
             },
             {
+                network: 'optimism',
+                chainId: 10,
+                urls: {
+                    apiURL: 'https://api-optimistic.etherscan.io/api',
+                    browserURL: 'https://optimistic.etherscan.io/',
+                },
+            },
+            {
+                network: 'arbitrum',
+                chainId: 42161,
+                urls: {
+                    apiURL: 'https://api.arbiscan.io/api',
+                    browserURL: 'https://arbiscan.io/',
+                },
+            },
+
+            // ===== Testnet Networks =====
+            {
                 network: 'sepolia',
                 chainId: 11155111,
                 urls: {
@@ -100,6 +157,22 @@ const config: HardhatUserConfig = {
                 urls: {
                     apiURL: 'https://api-sepolia.basescan.org/api',
                     browserURL: 'https://sepolia.basescan.org/',
+                },
+            },
+            {
+                network: 'optimismSepolia',
+                chainId: 11155420,
+                urls: {
+                    apiURL: 'https://api-sepolia-optimistic.etherscan.io/api',
+                    browserURL: 'https://sepolia-optimistic.etherscan.io/',
+                },
+            },
+            {
+                network: 'arbitrumSepolia',
+                chainId: 421614,
+                urls: {
+                    apiURL: 'https://api-sepolia.arbiscan.io/api',
+                    browserURL: 'https://sepolia.arbiscan.io/',
                 },
             },
         ],

--- a/contract/hardhat.config.ts
+++ b/contract/hardhat.config.ts
@@ -43,7 +43,7 @@ const config: HardhatUserConfig = {
             accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
         },
         optimism: {
-            url: process.env.OPTIMISM_RPC_URL,
+            url: process.env.OPTIMISM_RPC_URL || '',
             chainId: 10,
             ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
                 ? [process.env.LEDGER_ADDRESS]
@@ -51,7 +51,7 @@ const config: HardhatUserConfig = {
             accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
         },
         arbitrum: {
-            url: process.env.ARBITRUM_RPC_URL,
+            url: process.env.ARBITRUM_RPC_URL || '',
             chainId: 42161,
             ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
                 ? [process.env.LEDGER_ADDRESS]
@@ -77,7 +77,7 @@ const config: HardhatUserConfig = {
             accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
         },
         optimismSepolia: {
-            url: process.env.OPTIMISM_SEPOLIA_RPC_URL,
+            url: process.env.OPTIMISM_SEPOLIA_RPC_URL || '',
             chainId: 11155420,
             ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
                 ? [process.env.LEDGER_ADDRESS]
@@ -85,7 +85,7 @@ const config: HardhatUserConfig = {
             accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
         },
         arbitrumSepolia: {
-            url: process.env.ARBITRUM_SEPOLIA_RPC_URL,
+            url: process.env.ARBITRUM_SEPOLIA_RPC_URL || '',
             chainId: 421614,
             ledgerAccounts: process.env.USE_LEDGER === 'true' && process.env.LEDGER_ADDRESS
                 ? [process.env.LEDGER_ADDRESS]

--- a/contract/lib/helpers.ts
+++ b/contract/lib/helpers.ts
@@ -214,6 +214,12 @@ export function getSafeWebUrl(
         case "base":
             query = `${query}base:${safeAddress}`;
             break;
+        case "optimism":
+            query = `${query}opt:${safeAddress}`;
+            break;
+        case "arbitrum":
+            query = `${query}arb:${safeAddress}`;
+            break;
 
         // Testnets
         case "sepolia":
@@ -221,6 +227,12 @@ export function getSafeWebUrl(
             break;
         case "baseSepolia":
             query = `${query}basesep:${safeAddress}`;
+            break;
+        case "optimismSepolia":
+            query = `${query}optsep:${safeAddress}`;
+            break;
+        case "arbitrumSepolia":
+            query = `${query}arbsep:${safeAddress}`;
             break;
         default:
             query = `${query}${safeAddress}`;

--- a/contract/lib/helpers.ts
+++ b/contract/lib/helpers.ts
@@ -215,10 +215,10 @@ export function getSafeWebUrl(
             query = `${query}base:${safeAddress}`;
             break;
         case "optimism":
-            query = `${query}opt:${safeAddress}`;
+            query = `${query}oeth:${safeAddress}`;
             break;
         case "arbitrum":
-            query = `${query}arb:${safeAddress}`;
+            query = `${query}arb1:${safeAddress}`;
             break;
 
         // Testnets
@@ -229,10 +229,12 @@ export function getSafeWebUrl(
             query = `${query}basesep:${safeAddress}`;
             break;
         case "optimismSepolia":
-            query = `${query}optsep:${safeAddress}`;
+            // TODO: validate once support added in the UI
+            query = `${query}oethsep:${safeAddress}`;
             break;
         case "arbitrumSepolia":
-            query = `${query}arbsep:${safeAddress}`;
+            // TODO: validate once support added in the UI
+            query = `${query}arb1sep:${safeAddress}`;
             break;
         default:
             query = `${query}${safeAddress}`;


### PR DESCRIPTION
add support for chain interactions via RPC, and block explorer contract verification, for the following chains:
- OP Mainnet (optimism)
- OP Sepolia (optimismSepolia)
- Arbitrum One (arbitrum)
- Arbitrum Sepolia (arbitrumSepolia)